### PR TITLE
added testcases for hex and micro

### DIFF
--- a/smashlib/test_hex.py
+++ b/smashlib/test_hex.py
@@ -1,101 +1,108 @@
+import io
 import unittest
 from unittest.mock import Mock
-import errno 
-import builtins
-import io
-from .hexfile import Hex,HexFile,HexError
+from unittest.mock import patch
+from .hexfile import Hex, HexFile, HexError
 
 class SimpleTest(unittest.TestCase):
-	hex_data = Hex(b":03000000020008")
-	byte = io.BytesIO(b":03000000020008f3")
-	builtins.open = Mock(return_value=byte)
-	hex_read = HexFile(byte)
+    def setUp(self):
+        self.hex_data = Hex(b":03000000020008")
+        string = io.BytesIO(b":03000000020008f3")
+        m_open = Mock(return_value=string)
+        with patch('builtins.open', m_open):
+            self.hex_read = HexFile('')
+    def test_checksum(self):
+        self.assertEqual(self.hex_data.append_checksum(b":03000000020008"), b":03000000020008f3")
 
-	def test_checksum(self):
-		self.assertEqual(self.hex_data.append_checksum(b":03000000020008"), b":03000000020008f3")
-		
-	def test_get_type(self):
-		self.assertEqual(self.hex_data.get_type(), b"00")
-	
-	def test_is_data(self):
-		self.assertEqual(self.hex_data.is_data(), 1)
-		
-	def test_is_eof(self):
-		self.assertEqual(self.hex_data.is_eof(), 0)
+    def test_get_type(self):
+        self.assertEqual(self.hex_data.get_type(), b"00")
 
-	def test_addr(self):
-		self.assertEqual(self.hex_data.addr(), 0000)		 
+    def test_is_data(self):
+        self.assertEqual(self.hex_data.is_data(), 1)
 
-	def test_data(self):
-		self.assertEqual(self.hex_data.data(), (2, 0, 8))
-		
-	def test_datalen(self):
-		self.assertEqual(self.hex_data.datalen(), 3)	
-	
-	def test_get_hex(self):
-		self.assertEqual(self.hex_data.get_hex(), b":03000000020008")	
+    def test_is_eof(self):
+        self.assertEqual(self.hex_data.is_eof(), 0)
 
-	def test__bytes__(self):
-		self.assertEqual(self.hex_data.__bytes__(), b":03000000020008")	
-			
-	def test_block_from_addr(self):
-		self.assertEqual(self.hex_read.block_from_addr(1010, [(0000, 1111)]), 0)
+    def test_addr(self):
+        self.assertEqual(self.hex_data.addr(), 0000)
 
-	def test_iter(self):
-		self.assertEqual(self.hex_read.rewind(), None)
+    def test_data(self):
+        self.assertEqual(self.hex_data.data(), (2, 0, 8))
 
-	def test_data_bytes(self):
-		self.assertEqual(self.hex_read.count_data_bytes(), 3)
+    def test_datalen(self):
+        self.assertEqual(self.hex_data.datalen(), 3)
 
-	def test_data_data(self):
-		data = self.hex_read.data_bytes()
-		l = []
-		for i in (data):
-			l.append(i)
-		self.assertEqual(l, [(0, 2), (1, 0), (2, 8)])
+    def test_get_hex(self):
+        self.assertEqual(self.hex_data.get_hex(), b":03000000020008")
 
-	def test_used_blocks(self):
-		self.assertEqual(self.hex_read.used_blocks([(0000, 1111)]), [0])
+    def test__bytes__(self):
+        self.assertEqual(self.hex_data.__bytes__(), b":03000000020008")
 
-	def test_hex_error(self):
-		self.assertRaises(HexError,self.hex_data.append_checksum, 'N/A') 
+    def test_block_from_addr(self):
+        self.assertEqual(self.hex_read.block_from_addr(1010, [(0000, 1111)]), 0)
 
-	def test_hexfile_error(self):
-		self.assertRaises(HexError, Hex(":dfgh").data)
+    def test_iter(self):
+        self.assertEqual(self.hex_read.rewind(), None)
 
-	def test_addr_error(self):
-		self.assertRaises(HexError, Hex(":dfgh").addr)
+    def test_data_bytes(self):
+        self.assertEqual(self.hex_read.count_data_bytes(), 3)
 
-	def test_datalen_error(self): 
-		self.assertRaises(HexError, Hex(":ggg").datalen)
+    def test_data_data(self):
+        data = self.hex_read.data_bytes()
+        data_list = []
+        for i in (data):
+            data_list.append(i)
+        self.assertEqual(data_list, [(0, 2), (1, 0), (2, 8)])
 
-	def test_count_error(self):
-		error = io.BytesIO(b":03000000")
-		error.name = Mock()
-		error.name.return_value = "test"
-		builtins.open = Mock(return_value = error)
-		self.assertRaises(HexError, HexFile(error).count_data_bytes)
+    def test_used_blocks(self):
+        self.assertEqual(self.hex_read.used_blocks([(0000, 1111)]), [0])
 
-	def test_file_error(self):
-		error = io.BytesIO(b":03000001020008F3")
-		builtins.open = Mock(return_value = error)
-		self.assertRaises(StopIteration, HexFile(error).__next__)
-	
-	def test_block_error(self):
-		error = io.BytesIO(b":03gggg00020008F3")
-		builtins.open = Mock(return_value = error)
-		error.name = Mock()
-		error.name.return_value = "test"
-		self.assertRaises(HexError, HexFile(error).used_blocks, [(0000, 1111)])
+    def test_hex_error(self):
+        self.assertRaises(HexError, self.hex_data.append_checksum, 'N/A')
 
-	def test_block_data_error(self):
-		error = io.BytesIO(b":03000000020008F3")
-		builtins.open = Mock(return_value = error)
-		error.name = Mock()
-		error.name.return_value = "test" 
-		self.assertRaises(HexError, HexFile(error).used_blocks, [(-111, -222)])
+    def test_hexfile_error(self):
+        self.assertRaises(HexError, Hex(":dfgh").data)
 
-		
+    def test_addr_error(self):
+        self.assertRaises(HexError, Hex(":dfgh").addr)
+
+    def test_datalen_error(self):
+        self.assertRaises(HexError, Hex(":ggg").datalen)
+
+    def test_count_error(self):
+        string = io.BytesIO(b":03000000")
+        m_open = Mock(return_value=string)
+        with patch('builtins.open', m_open):
+            self.hex_read = HexFile('')
+        string.name = Mock()
+        string.name.return_value = "test"
+        self.assertRaises(HexError, self.hex_read.count_data_bytes)
+
+    def test_file_error(self):
+        string = io.BytesIO(b":03000001020008F3")
+        m_open = Mock(return_value=string)
+        with patch('builtins.open', m_open):
+            self.hex_read = HexFile('')
+        self.assertRaises(StopIteration, self.hex_read.__next__)
+
+    def test_block_error(self):
+        string = io.BytesIO(b":03gggg00020008F3")
+        m_open = Mock(return_value=string)
+        with patch('builtins.open', m_open):
+            self.hex_read = HexFile('')
+        string.name = Mock()
+        string.name.return_value = "test"
+        self.assertRaises(HexError, self.hex_read.used_blocks, [(0000, 1111)])
+
+    def test_block_data_error(self):
+        string = io.BytesIO(b":03000000020008F3")
+        m_open = Mock(return_value=string)
+        with patch('builtins.open', m_open):
+            self.hex_read = HexFile('')
+        string.name = Mock()
+        string.name.return_value = "test"
+        self.assertRaises(HexError, self.hex_read.used_blocks, [(-111, -222)])
 
 if __name__ == '__main__':
-	unittest.main()
+    unittest.main()
+

--- a/smashlib/test_hex.py
+++ b/smashlib/test_hex.py
@@ -1,8 +1,7 @@
 import io
 import unittest
-from unittest.mock import Mock
-from unittest.mock import patch
-from .hexfile import Hex, HexFile, HexError
+from unittest.mock import Mock, patch
+from hexfile import Hex, HexFile, HexError
 
 class SimpleTest(unittest.TestCase):
     def setUp(self):
@@ -50,7 +49,7 @@ class SimpleTest(unittest.TestCase):
     def test_data_data(self):
         data = self.hex_read.data_bytes()
         data_list = []
-        for i in (data):
+        for i in data:
             data_list.append(i)
         self.assertEqual(data_list, [(0, 2), (1, 0), (2, 8)])
 
@@ -69,39 +68,49 @@ class SimpleTest(unittest.TestCase):
     def test_datalen_error(self):
         self.assertRaises(HexError, Hex(":ggg").datalen)
 
+class SecondTest(unittest.TestCase):
+
     def test_count_error(self):
         string = io.BytesIO(b":03000000")
         m_open = Mock(return_value=string)
+        string.name = ''
         with patch('builtins.open', m_open):
-            self.hex_read = HexFile('')
-        string.name = Mock()
-        string.name.return_value = "test"
-        self.assertRaises(HexError, self.hex_read.count_data_bytes)
+            hex_read = HexFile('')
+        self.assertRaises(HexError, hex_read.count_data_bytes)
 
     def test_file_error(self):
         string = io.BytesIO(b":03000001020008F3")
         m_open = Mock(return_value=string)
         with patch('builtins.open', m_open):
-            self.hex_read = HexFile('')
-        self.assertRaises(StopIteration, self.hex_read.__next__)
+            hex_read = HexFile('')
+        self.assertRaises(StopIteration, next, hex_read)
 
     def test_block_error(self):
         string = io.BytesIO(b":03gggg00020008F3")
         m_open = Mock(return_value=string)
+        string.name = ''
         with patch('builtins.open', m_open):
-            self.hex_read = HexFile('')
-        string.name = Mock()
-        string.name.return_value = "test"
-        self.assertRaises(HexError, self.hex_read.used_blocks, [(0000, 1111)])
+            hex_read = HexFile('')
+        self.assertRaises(HexError, hex_read.used_blocks, [(0000, 1111)])
 
     def test_block_data_error(self):
         string = io.BytesIO(b":03000000020008F3")
         m_open = Mock(return_value=string)
+        string.name = ''
         with patch('builtins.open', m_open):
-            self.hex_read = HexFile('')
-        string.name = Mock()
-        string.name.return_value = "test"
-        self.assertRaises(HexError, self.hex_read.used_blocks, [(-111, -222)])
+            hex_read = HexFile('')
+        self.assertRaises(HexError, hex_read.used_blocks, [(-111, -222)])
+
+
+    def test_data_bytes_error(self):
+        string = io.BytesIO(b":03000000")
+        m_open = Mock(return_value=string)
+        string.name = ''
+        with patch('builtins.open', m_open):
+            hex_read = HexFile('')
+        self.assertRaises(HexError, next, hex_read.data_bytes())
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/smashlib/test_hex.py
+++ b/smashlib/test_hex.py
@@ -11,7 +11,9 @@ class HexTest(unittest.TestCase):
         self.m_open = Mock(return_value=string)
 
     def test_checksum(self):
-        self.assertEqual(self.hex_data.append_checksum(b":03000000020008"), b":03000000020008f3")
+        expected_value = b":03000000020008f3"
+        result = self.hex_data.append_checksum(b":03000000020008")
+        self.assertEqual(result, expected_value)
 
     def test_get_type(self):
         self.assertEqual(self.hex_data.get_type(), b"00")
@@ -26,48 +28,57 @@ class HexTest(unittest.TestCase):
         self.assertEqual(self.hex_data.addr(), 0000)
 
     def test_data(self):
-        self.assertEqual(self.hex_data.data(), (2, 0, 8))
+        expected_value = (2, 0, 8)
+        result = self.hex_data.data()
+        self.assertEqual(result, expected_value)
 
     def test_datalen(self):
         self.assertEqual(self.hex_data.datalen(), 3)
 
     def test_get_hex(self):
-        self.assertEqual(self.hex_data.get_hex(), b":03000000020008")
+        expected_value = b":03000000020008"
+        self.assertEqual(self.hex_data.get_hex(), expected_value)
 
     def test__bytes__(self):
-        self.assertEqual(self.hex_data.__bytes__(), b":03000000020008")
+        expected_value = b":03000000020008"
+        self.assertEqual(self.hex_data.__bytes__(), expected_value)
 
     def test_block_from_addr(self):
+        expected_value = 0
+        addr = 1010
+        addr_range = [(0000, 1111)]
         with patch('builtins.open', self.m_open):
-            self.hex_read = HexFile('')
-        self.assertEqual(self.hex_read.block_from_addr(1010, [(0000, 1111)]), 0)
+            hex_read = HexFile('')
+        result = hex_read.block_from_addr(addr, addr_range)
+        self.assertEqual(result, expected_value)
 
     def test_iter(self):
         with patch('builtins.open', self.m_open):
-            self.hex_read = HexFile('')
-        self.assertEqual(self.hex_read.rewind(), None)
+            hex_read = HexFile('')
+        self.assertEqual(hex_read.rewind(), None)
 
     def test_data_bytes(self):
         with patch('builtins.open', self.m_open):
-            self.hex_read = HexFile('')
-        self.assertEqual(self.hex_read.count_data_bytes(), 3)
+            hex_read = HexFile('')
+        self.assertEqual(hex_read.count_data_bytes(), 3)
 
     def test_data_data(self):
-        data = self.hex_read.data_bytes()
-        data_list = []
-        for i in data:
-            data_list.append(i)
-        self.assertEqual(data_list, [(0, 2), (1, 0), (2, 8)])
+        expected_value = [(0, 2), (1, 0), (2, 8)]
+        with patch('builtins.open', self.m_open):
+            hex_read = HexFile('')
+        data = hex_read.data_bytes()
+        self.assertEqual(list(data), expected_value)
 
     def test_used_blocks(self):
+        addr_range = [(0000, 1111)]
         with patch('builtins.open', self.m_open):
-            self.hex_read = HexFile('')
-        self.assertEqual(self.hex_read.used_blocks([(0000, 1111)]), [0])
+            hex_read = HexFile('')
+        result = hex_read.used_blocks(addr_range)
+        self.assertEqual(result, [0])
 
     def test_hex_error(self):
-        with patch('builtins.open', self.m_open):
-            self.hex_read = HexFile('')
-        self.assertRaises(HexError, self.hex_data.append_checksum, 'N/A')
+        result = self.hex_data.append_checksum
+        self.assertRaises(HexError, result, 'N/A')
 
     def test_hexfile_error(self):
         self.assertRaises(HexError, Hex(":dfgh").data)
@@ -99,18 +110,19 @@ class HexfileTest(unittest.TestCase):
         string = io.BytesIO(b":03gggg00020008F3")
         m_open = Mock(return_value=string)
         string.name = ''
+        expected_value = [(0000, 1111)]
         with patch('builtins.open', m_open):
             hex_read = HexFile('')
-        self.assertRaises(HexError, hex_read.used_blocks, [(0000, 1111)])
+        self.assertRaises(HexError, hex_read.used_blocks, expected_value)
 
     def test_block_data_error(self):
         string = io.BytesIO(b":03000000020008F3")
         m_open = Mock(return_value=string)
         string.name = ''
+        expected_value = [(-111, -222)]
         with patch('builtins.open', m_open):
             hex_read = HexFile('')
-        self.assertRaises(HexError, hex_read.used_blocks, [(-111, -222)])
-
+        self.assertRaises(HexError, hex_read.used_blocks, expected_value)
 
     def test_data_bytes_error(self):
         string = io.BytesIO(b":03000000")
@@ -122,4 +134,3 @@ class HexfileTest(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/smashlib/test_hex.py
+++ b/smashlib/test_hex.py
@@ -1,0 +1,101 @@
+import unittest
+from unittest.mock import Mock
+import errno 
+import builtins
+import io
+from .hexfile import Hex,HexFile,HexError
+
+class SimpleTest(unittest.TestCase):
+	hex_data = Hex(b":03000000020008")
+	byte = io.BytesIO(b":03000000020008f3")
+	builtins.open = Mock(return_value=byte)
+	hex_read = HexFile(byte)
+
+	def test_checksum(self):
+		self.assertEqual(self.hex_data.append_checksum(b":03000000020008"), b":03000000020008f3")
+		
+	def test_get_type(self):
+		self.assertEqual(self.hex_data.get_type(), b"00")
+	
+	def test_is_data(self):
+		self.assertEqual(self.hex_data.is_data(), 1)
+		
+	def test_is_eof(self):
+		self.assertEqual(self.hex_data.is_eof(), 0)
+
+	def test_addr(self):
+		self.assertEqual(self.hex_data.addr(), 0000)		 
+
+	def test_data(self):
+		self.assertEqual(self.hex_data.data(), (2, 0, 8))
+		
+	def test_datalen(self):
+		self.assertEqual(self.hex_data.datalen(), 3)	
+	
+	def test_get_hex(self):
+		self.assertEqual(self.hex_data.get_hex(), b":03000000020008")	
+
+	def test__bytes__(self):
+		self.assertEqual(self.hex_data.__bytes__(), b":03000000020008")	
+			
+	def test_block_from_addr(self):
+		self.assertEqual(self.hex_read.block_from_addr(1010, [(0000, 1111)]), 0)
+
+	def test_iter(self):
+		self.assertEqual(self.hex_read.rewind(), None)
+
+	def test_data_bytes(self):
+		self.assertEqual(self.hex_read.count_data_bytes(), 3)
+
+	def test_data_data(self):
+		data = self.hex_read.data_bytes()
+		l = []
+		for i in (data):
+			l.append(i)
+		self.assertEqual(l, [(0, 2), (1, 0), (2, 8)])
+
+	def test_used_blocks(self):
+		self.assertEqual(self.hex_read.used_blocks([(0000, 1111)]), [0])
+
+	def test_hex_error(self):
+		self.assertRaises(HexError,self.hex_data.append_checksum, 'N/A') 
+
+	def test_hexfile_error(self):
+		self.assertRaises(HexError, Hex(":dfgh").data)
+
+	def test_addr_error(self):
+		self.assertRaises(HexError, Hex(":dfgh").addr)
+
+	def test_datalen_error(self): 
+		self.assertRaises(HexError, Hex(":ggg").datalen)
+
+	def test_count_error(self):
+		error = io.BytesIO(b":03000000")
+		error.name = Mock()
+		error.name.return_value = "test"
+		builtins.open = Mock(return_value = error)
+		self.assertRaises(HexError, HexFile(error).count_data_bytes)
+
+	def test_file_error(self):
+		error = io.BytesIO(b":03000001020008F3")
+		builtins.open = Mock(return_value = error)
+		self.assertRaises(StopIteration, HexFile(error).__next__)
+	
+	def test_block_error(self):
+		error = io.BytesIO(b":03gggg00020008F3")
+		builtins.open = Mock(return_value = error)
+		error.name = Mock()
+		error.name.return_value = "test"
+		self.assertRaises(HexError, HexFile(error).used_blocks, [(0000, 1111)])
+
+	def test_block_data_error(self):
+		error = io.BytesIO(b":03000000020008F3")
+		builtins.open = Mock(return_value = error)
+		error.name = Mock()
+		error.name.return_value = "test" 
+		self.assertRaises(HexError, HexFile(error).used_blocks, [(-111, -222)])
+
+		
+
+if __name__ == '__main__':
+	unittest.main()

--- a/smashlib/test_hex.py
+++ b/smashlib/test_hex.py
@@ -7,8 +7,8 @@ class HexTest(unittest.TestCase):
 
     def setUp(self):
         self.hex_data = Hex(b":03000000020008")
-        string = io.BytesIO(b":03000000020008f3")
-        self.m_open = Mock(return_value=string)
+        hex_file = io.BytesIO(b":03000000020008f3")
+        self.m_open = Mock(return_value=hex_file)
 
     def test_checksum(self):
         expected_value = b":03000000020008f3"
@@ -92,42 +92,42 @@ class HexTest(unittest.TestCase):
 class HexfileTest(unittest.TestCase):
 
     def test_count_error(self):
-        string = io.BytesIO(b":03000000")
-        m_open = Mock(return_value=string)
-        string.name = ''
+        hex_file = io.BytesIO(b":03000000")
+        m_open = Mock(return_value=hex_file)
+        hex_file.name = ''
         with patch('builtins.open', m_open):
             hex_read = HexFile('')
         self.assertRaises(HexError, hex_read.count_data_bytes)
 
     def test_file_error(self):
-        string = io.BytesIO(b":03000001020008F3")
-        m_open = Mock(return_value=string)
+        hex_file = io.BytesIO(b":03000001020008F3")
+        m_open = Mock(return_value=hex_file)
         with patch('builtins.open', m_open):
             hex_read = HexFile('')
         self.assertRaises(StopIteration, next, hex_read)
 
     def test_block_error(self):
-        string = io.BytesIO(b":03gggg00020008F3")
-        m_open = Mock(return_value=string)
-        string.name = ''
+        hex_file = io.BytesIO(b":03gggg00020008F3")
+        m_open = Mock(return_value=hex_file)
+        hex_file.name = ''
         expected_value = [(0000, 1111)]
         with patch('builtins.open', m_open):
             hex_read = HexFile('')
         self.assertRaises(HexError, hex_read.used_blocks, expected_value)
 
     def test_block_data_error(self):
-        string = io.BytesIO(b":03000000020008F3")
-        m_open = Mock(return_value=string)
-        string.name = ''
+        hex_file = io.BytesIO(b":03000000020008F3")
+        m_open = Mock(return_value=hex_file)
+        hex_file.name = ''
         expected_value = [(-111, -222)]
         with patch('builtins.open', m_open):
             hex_read = HexFile('')
         self.assertRaises(HexError, hex_read.used_blocks, expected_value)
 
     def test_data_bytes_error(self):
-        string = io.BytesIO(b":03000000")
-        m_open = Mock(return_value=string)
-        string.name = ''
+        hex_file = io.BytesIO(b":03000000")
+        m_open = Mock(return_value=hex_file)
+        hex_file.name = ''
         with patch('builtins.open', m_open):
             hex_read = HexFile('')
         self.assertRaises(HexError, next, hex_read.data_bytes())

--- a/smashlib/test_hex.py
+++ b/smashlib/test_hex.py
@@ -1,15 +1,15 @@
 import io
 import unittest
 from unittest.mock import Mock, patch
-from hexfile import Hex, HexFile, HexError
+from .hexfile import Hex, HexFile, HexError
 
-class SimpleTest(unittest.TestCase):
+class HexTest(unittest.TestCase):
+
     def setUp(self):
         self.hex_data = Hex(b":03000000020008")
         string = io.BytesIO(b":03000000020008f3")
-        m_open = Mock(return_value=string)
-        with patch('builtins.open', m_open):
-            self.hex_read = HexFile('')
+        self.m_open = Mock(return_value=string)
+
     def test_checksum(self):
         self.assertEqual(self.hex_data.append_checksum(b":03000000020008"), b":03000000020008f3")
 
@@ -38,12 +38,18 @@ class SimpleTest(unittest.TestCase):
         self.assertEqual(self.hex_data.__bytes__(), b":03000000020008")
 
     def test_block_from_addr(self):
+        with patch('builtins.open', self.m_open):
+            self.hex_read = HexFile('')
         self.assertEqual(self.hex_read.block_from_addr(1010, [(0000, 1111)]), 0)
 
     def test_iter(self):
+        with patch('builtins.open', self.m_open):
+            self.hex_read = HexFile('')
         self.assertEqual(self.hex_read.rewind(), None)
 
     def test_data_bytes(self):
+        with patch('builtins.open', self.m_open):
+            self.hex_read = HexFile('')
         self.assertEqual(self.hex_read.count_data_bytes(), 3)
 
     def test_data_data(self):
@@ -54,9 +60,13 @@ class SimpleTest(unittest.TestCase):
         self.assertEqual(data_list, [(0, 2), (1, 0), (2, 8)])
 
     def test_used_blocks(self):
+        with patch('builtins.open', self.m_open):
+            self.hex_read = HexFile('')
         self.assertEqual(self.hex_read.used_blocks([(0000, 1111)]), [0])
 
     def test_hex_error(self):
+        with patch('builtins.open', self.m_open):
+            self.hex_read = HexFile('')
         self.assertRaises(HexError, self.hex_data.append_checksum, 'N/A')
 
     def test_hexfile_error(self):
@@ -68,7 +78,7 @@ class SimpleTest(unittest.TestCase):
     def test_datalen_error(self):
         self.assertRaises(HexError, Hex(":ggg").datalen)
 
-class SecondTest(unittest.TestCase):
+class HexfileTest(unittest.TestCase):
 
     def test_count_error(self):
         string = io.BytesIO(b":03000000")
@@ -109,8 +119,6 @@ class SecondTest(unittest.TestCase):
         with patch('builtins.open', m_open):
             hex_read = HexFile('')
         self.assertRaises(HexError, next, hex_read.data_bytes())
-
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/smashlib/test_micro.py
+++ b/smashlib/test_micro.py
@@ -5,7 +5,6 @@ from smashlib.micro import Micro
 from smashlib.micro import  HexDispData, HexBlankCheck, ProtoError
 from smashlib.micro import IspChecksumError, IspProgError, IspTimeoutError
 
-
 class HexTestCase(unittest.TestCase):
 
     def test_dispdata(self):
@@ -30,12 +29,13 @@ class HexTestCase(unittest.TestCase):
         self.assertRaisesRegex(ValueError, "check end address 0x43266 out of range",
                                HexBlankCheck, 0x5432, 0x43266)
 
-class MockTestCase(unittest.TestCase):
+class MicroTestCase(unittest.TestCase):
+
     def setUp(self):
         self.serial = Mock()
         self.micro_obj = Micro("P89V51RD2", 12, self.serial)
 
-    def data(self):
+    def file_obj(self):
         string = io.BytesIO(b":0300610002000397\n:0300610002000397")
         m_open = Mock(return_value=string)
         return m_open
@@ -100,7 +100,6 @@ class MockTestCase(unittest.TestCase):
         data = [b'0x0001=0E', b''] * 8
         self.micro_obj.serial.read_timeo.side_effect = data
         self.assertRaises(ProtoError, lambda: self.micro_obj[0x0000])
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/smashlib/test_micro.py
+++ b/smashlib/test_micro.py
@@ -52,14 +52,14 @@ class MicroTestCase(unittest.TestCase):
 
     def test_program_file(self):
         self.serial.wait_for.return_value = b"."
-        with patch('builtins.open', self.data()):
+        with patch('builtins.open', self.file_obj()):
             self.micro_obj.prog_file("", Mock())
         self.assertEqual(self.micro_obj.serial.write.called, True)
         self.assertEqual(self.micro_obj.serial.wait_for.called, True)
 
     def test_send_cmd_checksum(self):
         self.serial.wait_for.return_value = b"X"
-        with patch('builtins.open', self.data()):
+        with patch('builtins.open', self.file_obj()):
             self.assertRaises(IspChecksumError, self.micro_obj.prog_file, "")
 
     def test_send_cmd_progem_error(self):
@@ -67,11 +67,12 @@ class MicroTestCase(unittest.TestCase):
         string = io.BytesIO(b":03000000020008")
         m_open = Mock(return_value=string)
         with patch('builtins.open', m_open):
-            self.assertRaises(IspProgError, self.micro_obj.prog_file, "")   
+            self.assertRaises(IspProgError, self.micro_obj.prog_file, "")
+
     def test_send_cmd_progem_error_3(self):
         self.serial.wait_for.return_value = b"P"
         string = io.BytesIO(b":03000000020008")
-        m_open = Mock(return_value=string)        
+        m_open = Mock(return_value=string)
         with patch('builtins.open', m_open):
             self.assertRaises(IspProgError, self.micro_obj.prog_file, "")
 
@@ -85,7 +86,7 @@ class MicroTestCase(unittest.TestCase):
         data = [b'0x0000', b''] * 8
         self.micro_obj.serial.read_timeo.side_effect = data
         self.assertRaises(ProtoError, lambda: self.micro_obj[0xffff])
-    
+
     def test__update_cache_with_line_addr_error(self):
         data = [b'0xghgj=pp', b''] * 8
         self.micro_obj.serial.read_timeo.side_effect = data
@@ -103,4 +104,3 @@ class MicroTestCase(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/smashlib/test_micro.py
+++ b/smashlib/test_micro.py
@@ -1,0 +1,123 @@
+import unittest
+from unittest.mock import Mock
+from smashlib.hexfile import Hex, HexFile, HexError
+from smashlib.smash import Serial
+from smashlib.micro import Micro
+import errno 
+import builtins
+import io
+from smashlib.micro import micro_info, HexDispData, HexBlankCheck, ProtoError, IspTimeoutError, IspChecksumError, IspProgError
+
+
+class MockTestCase(unittest.TestCase):
+
+	def setUp(self):
+		self.serial = Mock()
+		self.micro_obj = Micro("P89V51RD2", 12, self.serial)
+
+	def test_dispdata(self):
+		hex_disp = HexDispData(0x20, 0x8)
+		expected_value = b":050000040020000800cf"
+		self.assertEqual(hex_disp.hex, expected_value)
+
+	def test_blank_check(self):
+		hex_blank = HexBlankCheck(0x20, 0x8)
+		expected_value = b":050000040020000801ce"
+		self.assertEqual(hex_blank.hex, expected_value)
+
+	def test_sync_baudrate(self):
+		self.micro_obj.sync_baudrate()
+		self.assertEqual(self.micro_obj.serial.write.called, True)
+		self.assertEqual(self.micro_obj.serial.wait_for.called, True)
+		self.serial.wait_for.assert_called_with(b"U")
+
+
+	def test_send_cmd(self):
+		v = self.micro_obj._send_cmd(b"U", 2)
+		self.assertEqual(self.micro_obj.serial.write.called, True)
+		self.assertEqual(self.micro_obj.serial.wait_for.called, True)
+		self.assertEqual(v,  None)
+
+	def test_send_cmd_none(self):
+		self.serial.wait_for.return_value = b"."
+		v = self.micro_obj._send_cmd(b"U", None)
+		self.assertEqual(v,  None)
+
+	def test_send_cmd_checksum(self):
+		self.serial.wait_for.return_value = b"X"
+		self.assertRaises(IspChecksumError,  self.micro_obj._send_cmd, b"U", None)	
+
+
+	def test_send_cmd_progem_error(self):
+		self.serial.wait_for.return_value = b"R"
+		self.assertRaises(IspProgError,  self.micro_obj._send_cmd, b"U", None)
+
+	def test_send_cmd_progem_error_3(self):
+		self.serial.wait_for.return_value = b"P"
+		self.assertRaises(IspProgError,  self.micro_obj._send_cmd, b"U", None)
+
+	def test_send_cmd_progem_error_2(self):
+		self.serial.wait_for.return_value = b"P"
+		self.assertRaises(IspProgError,  self.micro_obj._send_cmd, b"U", None)
+
+	def test_program_file(self):
+		self.micro_obj._send_cmd = Mock()
+		byte = io.BytesIO(b":03000000020008f3")
+		builtins.open = Mock(return_value=byte)
+		data = 0
+		self.micro_obj.prog_file(byte, data)
+		self.micro_obj._send_cmd.assert_called_with(b':03000000020008f3')
+
+	def test_hex_dip(self):
+		self.assertRaisesRegex(ValueError, "data start address 0x54321 out of range", HexDispData, 0x54321, 0x4321)
+		self.assertRaisesRegex(ValueError, "data end address 0x43266 out of range", HexDispData, 0x5432, 0x43266)
+
+	def test_hex_dip_error(self):
+		self.assertRaisesRegex(ValueError, "check start address 0x54321 out of range", HexBlankCheck, 0x54321, 0x4321)
+		self.assertRaisesRegex(ValueError, "check end address 0x43266 out of range", HexBlankCheck, 0x5432, 0x43266)
+
+	def test__getitem__(self):
+		data = [b'0x0000=0E', b'']
+		self.micro_obj.serial.read_timeo = Mock(side_effect = data)
+		self.micro_obj.__getitem__(0x0000)
+		self.assertEqual(self.micro_obj.serial.write.called, True)	
+
+	def test_update_cache_with_data(self):
+		self.micro_obj._update_cache_with_line = Mock()
+		v = self.micro_obj._update_cache_with_data(b'0x0000=0E')
+		self.micro_obj._update_cache_with_line.assert_called_with(b'0x0000=0E')
+		self.assertEqual(v, None)
+
+	def test_update_line(self):
+		v = self.micro_obj._update_cache_with_line(b'0x0000=0E')
+		self.assertEqual(v, None)
+
+	def test_update_cache(self):
+		data = [b'0x0000=0E', b'']
+		self.micro_obj._update_cache_with_data = Mock()
+		self.micro_obj.serial.read_timeo = Mock(side_effect = data)
+		self.micro_obj._update_cache(0x0000)
+		self.assertEqual(self.micro_obj.serial.write.called, True)
+		self.micro_obj._update_cache_with_data.assert_called_with(b'0x0000=0E')
+		
+	def test_getitem(self):
+		data = [b'0x0000=0E', b'']
+		self.micro_obj.serial.read_timeo = Mock(side_effect = data)
+		self.assertEqual(self.micro_obj._getitem(0x0000), 14)
+		self.assertEqual(self.micro_obj.serial.write.called, True)
+
+	def test__update_cache_with_line_error(self):
+		self.assertRaises(ProtoError, self.micro_obj._update_cache_with_line, b'0x0000+0E')
+
+	def test__update_cache_with_line_addr_error(self):
+		self.assertRaises(ProtoError, self.micro_obj._update_cache_with_line, b'0xghgj=0E')	
+
+	def test_getitem_error(self):
+		data = [b'0x0001=0E', b'']
+		self.micro_obj.serial.read_timeo = Mock(side_effect = data)
+		self.assertRaises(ProtoError, self.micro_obj._getitem, 0x0001)
+	
+
+
+if __name__ == '__main__':
+	unittest.main()

--- a/smashlib/test_micro.py
+++ b/smashlib/test_micro.py
@@ -36,8 +36,8 @@ class MicroTestCase(unittest.TestCase):
         self.micro_obj = Micro("P89V51RD2", 12, self.serial)
 
     def file_obj(self):
-        string = io.BytesIO(b":0300610002000397\n:0300610002000397")
-        m_open = Mock(return_value=string)
+        hex_file = io.BytesIO(b":0300610002000397\n:0300610002000397")
+        m_open = Mock(return_value=hex_file)
         return m_open
 
     def test_sync_baudrate(self):
@@ -64,15 +64,15 @@ class MicroTestCase(unittest.TestCase):
 
     def test_send_cmd_progem_error(self):
         self.serial.wait_for.return_value = b"R"
-        string = io.BytesIO(b":03000000020008")
-        m_open = Mock(return_value=string)
+        hex_file = io.BytesIO(b":03000000020008")
+        m_open = Mock(return_value=hex_file)
         with patch('builtins.open', m_open):
             self.assertRaises(IspProgError, self.micro_obj.prog_file, "")
 
     def test_send_cmd_progem_error_3(self):
         self.serial.wait_for.return_value = b"P"
-        string = io.BytesIO(b":03000000020008")
-        m_open = Mock(return_value=string)
+        hex_file = io.BytesIO(b":03000000020008")
+        m_open = Mock(return_value=hex_file)
         with patch('builtins.open', m_open):
             self.assertRaises(IspProgError, self.micro_obj.prog_file, "")
 

--- a/smashlib/test_micro.py
+++ b/smashlib/test_micro.py
@@ -1,123 +1,120 @@
+import io
 import unittest
 from unittest.mock import Mock
-from smashlib.hexfile import Hex, HexFile, HexError
-from smashlib.smash import Serial
+from unittest.mock import patch
 from smashlib.micro import Micro
-import errno 
-import builtins
-import io
-from smashlib.micro import micro_info, HexDispData, HexBlankCheck, ProtoError, IspTimeoutError, IspChecksumError, IspProgError
-
+from smashlib.micro import  HexDispData, HexBlankCheck, ProtoError
+from smashlib.micro import IspChecksumError, IspProgError
 
 class MockTestCase(unittest.TestCase):
+    def setUp(self):
+        self.serial = Mock()
+        self.micro_obj = Micro("P89V51RD2", 12, self.serial)
 
-	def setUp(self):
-		self.serial = Mock()
-		self.micro_obj = Micro("P89V51RD2", 12, self.serial)
+    def test_dispdata(self):
+        hex_disp = HexDispData(0x20, 0x8)
+        expected_value = b":050000040020000800cf"
+        self.assertEqual(hex_disp.hex, expected_value)
 
-	def test_dispdata(self):
-		hex_disp = HexDispData(0x20, 0x8)
-		expected_value = b":050000040020000800cf"
-		self.assertEqual(hex_disp.hex, expected_value)
+    def test_blank_check(self):
+        hex_blank = HexBlankCheck(0x20, 0x8)
+        expected_value = b":050000040020000801ce"
+        self.assertEqual(hex_blank.hex, expected_value)
 
-	def test_blank_check(self):
-		hex_blank = HexBlankCheck(0x20, 0x8)
-		expected_value = b":050000040020000801ce"
-		self.assertEqual(hex_blank.hex, expected_value)
+    def test_sync_baudrate(self):
+        self.micro_obj.sync_baudrate()
+        self.assertEqual(self.micro_obj.serial.write.called, True)
+        self.assertEqual(self.micro_obj.serial.wait_for.called, True)
+        self.serial.wait_for.assert_called_with(b"U")
 
-	def test_sync_baudrate(self):
-		self.micro_obj.sync_baudrate()
-		self.assertEqual(self.micro_obj.serial.write.called, True)
-		self.assertEqual(self.micro_obj.serial.wait_for.called, True)
-		self.serial.wait_for.assert_called_with(b"U")
+    def test_send_cmd(self):
+        data = self.micro_obj._send_cmd(b"U", 2)
+        self.assertEqual(self.micro_obj.serial.write.called, True)
+        self.assertEqual(self.micro_obj.serial.wait_for.called, True)
+        self.assertEqual(data, None)
 
+    def test_send_cmd_none(self):
+        self.serial.wait_for.return_value = b"."
+        data = self.micro_obj._send_cmd(b"U", None)
+        self.assertEqual(data, None)
 
-	def test_send_cmd(self):
-		v = self.micro_obj._send_cmd(b"U", 2)
-		self.assertEqual(self.micro_obj.serial.write.called, True)
-		self.assertEqual(self.micro_obj.serial.wait_for.called, True)
-		self.assertEqual(v,  None)
+    def test_send_cmd_checksum(self):
+        self.serial.wait_for.return_value = b"X"
+        self.assertRaises(IspChecksumError, self.micro_obj._send_cmd, b"U", None)
 
-	def test_send_cmd_none(self):
-		self.serial.wait_for.return_value = b"."
-		v = self.micro_obj._send_cmd(b"U", None)
-		self.assertEqual(v,  None)
+    def test_send_cmd_progem_error(self):
+        self.serial.wait_for.return_value = b"R"
+        self.assertRaises(IspProgError, self.micro_obj._send_cmd, b"U", None)
 
-	def test_send_cmd_checksum(self):
-		self.serial.wait_for.return_value = b"X"
-		self.assertRaises(IspChecksumError,  self.micro_obj._send_cmd, b"U", None)	
+    def test_send_cmd_progem_error_3(self):
+        self.serial.wait_for.return_value = b"P"
+        self.assertRaises(IspProgError, self.micro_obj._send_cmd, b"U", None)
 
+    def test_send_cmd_progem_error_2(self):
+        self.serial.wait_for.return_value = b"P"
+        self.assertRaises(IspProgError, self.micro_obj._send_cmd, b"U", None)
 
-	def test_send_cmd_progem_error(self):
-		self.serial.wait_for.return_value = b"R"
-		self.assertRaises(IspProgError,  self.micro_obj._send_cmd, b"U", None)
+    def test_program_file(self):
+        self.micro_obj._send_cmd = Mock()
+        string = io.BytesIO(b":03000000020008f3")
+        m_open = Mock(return_value=string)
+        with patch('builtins.open', m_open):
+            self.micro_obj.prog_file("")
+        self.micro_obj._send_cmd.assert_called_with(b':03000000020008f3')
 
-	def test_send_cmd_progem_error_3(self):
-		self.serial.wait_for.return_value = b"P"
-		self.assertRaises(IspProgError,  self.micro_obj._send_cmd, b"U", None)
+    def test_hex_dip(self):
+        self.assertRaisesRegex(ValueError, "data start address 0x54321 out of range",
+                               HexDispData, 0x54321, 0x4321)
+        self.assertRaisesRegex(ValueError, "data end address 0x43266 out of range",
+                               HexDispData, 0x5432, 0x43266)
 
-	def test_send_cmd_progem_error_2(self):
-		self.serial.wait_for.return_value = b"P"
-		self.assertRaises(IspProgError,  self.micro_obj._send_cmd, b"U", None)
+    def test_hex_dip_error(self):
+        self.assertRaisesRegex(ValueError, "check start address 0x54321 out of range",
+                               HexBlankCheck, 0x54321, 0x4321)
+        self.assertRaisesRegex(ValueError, "check end address 0x43266 out of range",
+                               HexBlankCheck, 0x5432, 0x43266)
 
-	def test_program_file(self):
-		self.micro_obj._send_cmd = Mock()
-		byte = io.BytesIO(b":03000000020008f3")
-		builtins.open = Mock(return_value=byte)
-		data = 0
-		self.micro_obj.prog_file(byte, data)
-		self.micro_obj._send_cmd.assert_called_with(b':03000000020008f3')
+    def test__getitem__(self):
+        data = [b'0x0000=0E', b'']
+        self.micro_obj.serial.read_timeo = Mock(side_effect=data)
+        self.micro_obj.__getitem__(0x0000)
+        self.assertEqual(self.micro_obj.serial.write.called, True)
 
-	def test_hex_dip(self):
-		self.assertRaisesRegex(ValueError, "data start address 0x54321 out of range", HexDispData, 0x54321, 0x4321)
-		self.assertRaisesRegex(ValueError, "data end address 0x43266 out of range", HexDispData, 0x5432, 0x43266)
+    def test_update_cache_with_data(self):
+        self.micro_obj._update_cache_with_line = Mock()
+        data = self.micro_obj._update_cache_with_data(b'0x0000=0E')
+        self.micro_obj._update_cache_with_line.assert_called_with(b'0x0000=0E')
+        self.assertEqual(data, None)
 
-	def test_hex_dip_error(self):
-		self.assertRaisesRegex(ValueError, "check start address 0x54321 out of range", HexBlankCheck, 0x54321, 0x4321)
-		self.assertRaisesRegex(ValueError, "check end address 0x43266 out of range", HexBlankCheck, 0x5432, 0x43266)
+    def test_update_line(self):
+        data = self.micro_obj._update_cache_with_line(b'0x0000=0E')
+        self.assertEqual(data, None)
 
-	def test__getitem__(self):
-		data = [b'0x0000=0E', b'']
-		self.micro_obj.serial.read_timeo = Mock(side_effect = data)
-		self.micro_obj.__getitem__(0x0000)
-		self.assertEqual(self.micro_obj.serial.write.called, True)	
+    def test_update_cache(self):
+        data = [b'0x0000=0E', b'']
+        self.micro_obj._update_cache_with_data = Mock()
+        self.micro_obj.serial.read_timeo = Mock(side_effect=data)
+        self.micro_obj._update_cache(0x0000)
+        self.assertEqual(self.micro_obj.serial.write.called, True)
+        self.micro_obj._update_cache_with_data.assert_called_with(b'0x0000=0E')
 
-	def test_update_cache_with_data(self):
-		self.micro_obj._update_cache_with_line = Mock()
-		v = self.micro_obj._update_cache_with_data(b'0x0000=0E')
-		self.micro_obj._update_cache_with_line.assert_called_with(b'0x0000=0E')
-		self.assertEqual(v, None)
+    def test_getitem(self):
+        data = [b'0x0000=0E', b'']
+        self.micro_obj.serial.read_timeo = Mock(side_effect=data)
+        self.assertEqual(self.micro_obj._getitem(0x0000), 14)
+        self.assertEqual(self.micro_obj.serial.write.called, True)
 
-	def test_update_line(self):
-		v = self.micro_obj._update_cache_with_line(b'0x0000=0E')
-		self.assertEqual(v, None)
+    def test__update_cache_with_line_error(self):
+        self.assertRaises(ProtoError, self.micro_obj._update_cache_with_line, b'0x0000+0E')
 
-	def test_update_cache(self):
-		data = [b'0x0000=0E', b'']
-		self.micro_obj._update_cache_with_data = Mock()
-		self.micro_obj.serial.read_timeo = Mock(side_effect = data)
-		self.micro_obj._update_cache(0x0000)
-		self.assertEqual(self.micro_obj.serial.write.called, True)
-		self.micro_obj._update_cache_with_data.assert_called_with(b'0x0000=0E')
-		
-	def test_getitem(self):
-		data = [b'0x0000=0E', b'']
-		self.micro_obj.serial.read_timeo = Mock(side_effect = data)
-		self.assertEqual(self.micro_obj._getitem(0x0000), 14)
-		self.assertEqual(self.micro_obj.serial.write.called, True)
+    def test__update_cache_with_line_addr_error(self):
+        self.assertRaises(ProtoError, self.micro_obj._update_cache_with_line, b'0xghgj=0E')
 
-	def test__update_cache_with_line_error(self):
-		self.assertRaises(ProtoError, self.micro_obj._update_cache_with_line, b'0x0000+0E')
-
-	def test__update_cache_with_line_addr_error(self):
-		self.assertRaises(ProtoError, self.micro_obj._update_cache_with_line, b'0xghgj=0E')	
-
-	def test_getitem_error(self):
-		data = [b'0x0001=0E', b'']
-		self.micro_obj.serial.read_timeo = Mock(side_effect = data)
-		self.assertRaises(ProtoError, self.micro_obj._getitem, 0x0001)
-	
-
+    def test_getitem_error(self):
+        data = [b'0x0001=0E', b'']
+        self.micro_obj.serial.read_timeo = Mock(side_effect=data)
+        self.assertRaises(ProtoError, self.micro_obj._getitem, 0x0001)
 
 if __name__ == '__main__':
-	unittest.main()
+    unittest.main()
+

--- a/smashlib/test_micro.py
+++ b/smashlib/test_micro.py
@@ -1,15 +1,12 @@
 import io
 import unittest
-from unittest.mock import Mock
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 from smashlib.micro import Micro
 from smashlib.micro import  HexDispData, HexBlankCheck, ProtoError
-from smashlib.micro import IspChecksumError, IspProgError
+from smashlib.micro import IspChecksumError, IspProgError, IspTimeoutError
 
-class MockTestCase(unittest.TestCase):
-    def setUp(self):
-        self.serial = Mock()
-        self.micro_obj = Micro("P89V51RD2", 12, self.serial)
+
+class HexTestCase(unittest.TestCase):
 
     def test_dispdata(self):
         hex_disp = HexDispData(0x20, 0x8)
@@ -20,47 +17,6 @@ class MockTestCase(unittest.TestCase):
         hex_blank = HexBlankCheck(0x20, 0x8)
         expected_value = b":050000040020000801ce"
         self.assertEqual(hex_blank.hex, expected_value)
-
-    def test_sync_baudrate(self):
-        self.micro_obj.sync_baudrate()
-        self.assertEqual(self.micro_obj.serial.write.called, True)
-        self.assertEqual(self.micro_obj.serial.wait_for.called, True)
-        self.serial.wait_for.assert_called_with(b"U")
-
-    def test_send_cmd(self):
-        data = self.micro_obj._send_cmd(b"U", 2)
-        self.assertEqual(self.micro_obj.serial.write.called, True)
-        self.assertEqual(self.micro_obj.serial.wait_for.called, True)
-        self.assertEqual(data, None)
-
-    def test_send_cmd_none(self):
-        self.serial.wait_for.return_value = b"."
-        data = self.micro_obj._send_cmd(b"U", None)
-        self.assertEqual(data, None)
-
-    def test_send_cmd_checksum(self):
-        self.serial.wait_for.return_value = b"X"
-        self.assertRaises(IspChecksumError, self.micro_obj._send_cmd, b"U", None)
-
-    def test_send_cmd_progem_error(self):
-        self.serial.wait_for.return_value = b"R"
-        self.assertRaises(IspProgError, self.micro_obj._send_cmd, b"U", None)
-
-    def test_send_cmd_progem_error_3(self):
-        self.serial.wait_for.return_value = b"P"
-        self.assertRaises(IspProgError, self.micro_obj._send_cmd, b"U", None)
-
-    def test_send_cmd_progem_error_2(self):
-        self.serial.wait_for.return_value = b"P"
-        self.assertRaises(IspProgError, self.micro_obj._send_cmd, b"U", None)
-
-    def test_program_file(self):
-        self.micro_obj._send_cmd = Mock()
-        string = io.BytesIO(b":03000000020008f3")
-        m_open = Mock(return_value=string)
-        with patch('builtins.open', m_open):
-            self.micro_obj.prog_file("")
-        self.micro_obj._send_cmd.assert_called_with(b':03000000020008f3')
 
     def test_hex_dip(self):
         self.assertRaisesRegex(ValueError, "data start address 0x54321 out of range",
@@ -74,46 +30,77 @@ class MockTestCase(unittest.TestCase):
         self.assertRaisesRegex(ValueError, "check end address 0x43266 out of range",
                                HexBlankCheck, 0x5432, 0x43266)
 
+class MockTestCase(unittest.TestCase):
+    def setUp(self):
+        self.serial = Mock()
+        self.micro_obj = Micro("P89V51RD2", 12, self.serial)
+
+    def data(self):
+        string = io.BytesIO(b":0300610002000397\n:0300610002000397")
+        m_open = Mock(return_value=string)
+        return m_open
+
+    def test_sync_baudrate(self):
+        self.micro_obj.sync_baudrate()
+        self.assertEqual(self.micro_obj.serial.write.called, True)
+        self.assertEqual(self.micro_obj.serial.wait_for.called, True)
+        self.serial.wait_for.assert_called_with(b"U")
+
+    def test_sync_baudrate_error(self):
+        self.serial.wait_for.side_effect = IspTimeoutError('')
+        self.assertRaises(IspTimeoutError, self.micro_obj.sync_baudrate)
+
+    def test_program_file(self):
+        self.serial.wait_for.return_value = b"."
+        with patch('builtins.open', self.data()):
+            self.micro_obj.prog_file("", Mock())
+        self.assertEqual(self.micro_obj.serial.write.called, True)
+        self.assertEqual(self.micro_obj.serial.wait_for.called, True)
+
+    def test_send_cmd_checksum(self):
+        self.serial.wait_for.return_value = b"X"
+        with patch('builtins.open', self.data()):
+            self.assertRaises(IspChecksumError, self.micro_obj.prog_file, "")
+
+    def test_send_cmd_progem_error(self):
+        self.serial.wait_for.return_value = b"R"
+        string = io.BytesIO(b":03000000020008")
+        m_open = Mock(return_value=string)
+        with patch('builtins.open', m_open):
+            self.assertRaises(IspProgError, self.micro_obj.prog_file, "")   
+    def test_send_cmd_progem_error_3(self):
+        self.serial.wait_for.return_value = b"P"
+        string = io.BytesIO(b":03000000020008")
+        m_open = Mock(return_value=string)        
+        with patch('builtins.open', m_open):
+            self.assertRaises(IspProgError, self.micro_obj.prog_file, "")
+
     def test__getitem__(self):
-        data = [b'0x0000=0E', b'']
-        self.micro_obj.serial.read_timeo = Mock(side_effect=data)
-        self.micro_obj.__getitem__(0x0000)
-        self.assertEqual(self.micro_obj.serial.write.called, True)
-
-    def test_update_cache_with_data(self):
-        self.micro_obj._update_cache_with_line = Mock()
-        data = self.micro_obj._update_cache_with_data(b'0x0000=0E')
-        self.micro_obj._update_cache_with_line.assert_called_with(b'0x0000=0E')
-        self.assertEqual(data, None)
-
-    def test_update_line(self):
-        data = self.micro_obj._update_cache_with_line(b'0x0000=0E')
-        self.assertEqual(data, None)
-
-    def test_update_cache(self):
-        data = [b'0x0000=0E', b'']
-        self.micro_obj._update_cache_with_data = Mock()
-        self.micro_obj.serial.read_timeo = Mock(side_effect=data)
-        self.micro_obj._update_cache(0x0000)
-        self.assertEqual(self.micro_obj.serial.write.called, True)
-        self.micro_obj._update_cache_with_data.assert_called_with(b'0x0000=0E')
-
-    def test_getitem(self):
-        data = [b'0x0000=0E', b'']
-        self.micro_obj.serial.read_timeo = Mock(side_effect=data)
-        self.assertEqual(self.micro_obj._getitem(0x0000), 14)
+        data = [b":", b"\r", b"0x0000=0E", b""]
+        self.micro_obj.serial.read_timeo.side_effect = data
+        self.assertEqual(self.micro_obj[0x0000], 14)
         self.assertEqual(self.micro_obj.serial.write.called, True)
 
     def test__update_cache_with_line_error(self):
-        self.assertRaises(ProtoError, self.micro_obj._update_cache_with_line, b'0x0000+0E')
-
+        data = [b'0x0000', b''] * 8
+        self.micro_obj.serial.read_timeo.side_effect = data
+        self.assertRaises(ProtoError, lambda: self.micro_obj[0xffff])
+    
     def test__update_cache_with_line_addr_error(self):
-        self.assertRaises(ProtoError, self.micro_obj._update_cache_with_line, b'0xghgj=0E')
+        data = [b'0xghgj=pp', b''] * 8
+        self.micro_obj.serial.read_timeo.side_effect = data
+        self.assertRaises(ProtoError, lambda: self.micro_obj[0x0000])
+
+    def test__update_cache_with_line_data_error(self):
+        data = [b'0xghgj=7', b''] * 8
+        self.micro_obj.serial.read_timeo.side_effect = data
+        self.assertRaises(ProtoError, lambda: self.micro_obj[0x0000])
 
     def test_getitem_error(self):
-        data = [b'0x0001=0E', b'']
-        self.micro_obj.serial.read_timeo = Mock(side_effect=data)
-        self.assertRaises(ProtoError, self.micro_obj._getitem, 0x0001)
+        data = [b'0x0001=0E', b''] * 8
+        self.micro_obj.serial.read_timeo.side_effect = data
+        self.assertRaises(ProtoError, lambda: self.micro_obj[0x0000])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I have written unittest for hexfile.py and micro.py file.
In that hexfile.py three test cases are failed, Because data() method in hexfile.py doesn't give all data from the given hex record line.
In hexfile.py  line number 104 there is logical error.
Error: for i in range(0, dlen, 2):
Expected: for i in range(0, (dlen*2), 2):